### PR TITLE
update plausible domain value

### DIFF
--- a/ansible/group_vars/gxconfig.yml
+++ b/ansible/group_vars/gxconfig.yml
@@ -926,7 +926,7 @@ base_app_main: &BASE_APP_MAIN
 
   # Please enter the URL for the Galaxy server so this can be used for
   # tracking with Plausible (https://plausible.io/).
-  plausible_domain: https://usegalaxy.esgwps.uno
+  plausible_domain: usegalaxy.esgwps.uno
 
   # Please enter the URL for the Matomo server (including https) so this
   # can be used for tracking with Matomo (https://matomo.org/).


### PR DESCRIPTION
without https the analytics collection works on 24.1